### PR TITLE
Fix issue with plugin.mts in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
     "sass": "^1.63.6",
     "typescript": "^5.1.6",
     "vitest": "^0.33.0"
+  },
+  "overrides": {
+    "mkdist": "1.2.0"
   }
 }


### PR DESCRIPTION
Hello, I did fork the library, and all worked, but I couldn't get it run. Only if I manually copy my plugin.mts file into the lib, which would be pain. I cloned the original lib too, and it also didn't work. Now I know why: mkdist, which Nuxt uses to convert .ts files in the nuxt builder, had an update 1 week ago. Normally, it just had a bug that it couldn't convert .mts, which got fixed, but made this library here broken. This here is a quick fix.

Btw this is the first time I ever forked a npm library

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/invictus-codes/nuxt-vuetify/21)
<!-- Reviewable:end -->
